### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/app/api/webhooks/replicate/[id]/route.ts
+++ b/app/api/webhooks/replicate/[id]/route.ts
@@ -3,6 +3,19 @@ import { createAdminClient } from "@/lib/supabase/admin";
 
 export const runtime = "edge";
 
+const ALLOWED_OUTPUT_HOSTS = new Set(["pbxt.replicate.delivery"]);
+
+function isAllowedOutputUrl(rawUrl: unknown): rawUrl is string {
+  if (typeof rawUrl !== "string") return false;
+
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.protocol === "https:" && ALLOWED_OUTPUT_HOSTS.has(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
 export async function POST(req: NextRequest) {
   const id = req.nextUrl.pathname.split("/")[4];
   const { output, status } = await req.json();
@@ -22,6 +35,10 @@ export async function POST(req: NextRequest) {
 
   // Prediction successful --> upload output to supabase storage --> update db output url --> user receives output via supabase realtime
   if (status === "succeeded") {
+    if (!isAllowedOutputUrl(output)) {
+      return new Response("Invalid output URL", { status: 400 });
+    }
+
     const blob = await fetch(output).then((res) => res.blob());
     const { data: storageData, error: storageError } = await supabase.storage
       .from("output")


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/extrapolate/security/code-scanning/1](https://github.com/lisagorewitdecker/extrapolate/security/code-scanning/1)

To fix this safely without changing intended behavior, validate `output` before calling `fetch`:

- Parse with `new URL(output)`.
- Allow only `https:` protocol.
- Enforce an explicit hostname allowlist for expected Replicate output hosts (server-controlled policy).
- Reject invalid/non-string URLs with `400`.
- Use the parsed/validated URL string for `fetch`.

Best change in `app/api/webhooks/replicate/[id]/route.ts`:
1. Add a small helper `isAllowedOutputUrl(rawUrl: unknown): rawUrl is string`.
2. In the `"succeeded"` branch, check `if (!isAllowedOutputUrl(output)) return new Response(..., { status: 400 })`.
3. Replace `fetch(output)` with `fetch(output)` only after validation (same variable, now narrowed and safe).

No new dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
