### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/app/api/webhooks/replicate/[id]/route.ts
+++ b/app/api/webhooks/replicate/[id]/route.ts
@@ -5,14 +5,22 @@ export const runtime = "edge";
 
 const ALLOWED_OUTPUT_HOSTS = new Set(["pbxt.replicate.delivery"]);
 
-function isAllowedOutputUrl(rawUrl: unknown): rawUrl is string {
-  if (typeof rawUrl !== "string") return false;
+function getValidatedOutputUrl(rawUrl: unknown): string | null {
+  if (typeof rawUrl !== "string") return null;
 
   try {
     const parsed = new URL(rawUrl);
-    return parsed.protocol === "https:" && ALLOWED_OUTPUT_HOSTS.has(parsed.hostname);
+
+    if (parsed.protocol !== "https:") return null;
+    if (!ALLOWED_OUTPUT_HOSTS.has(parsed.hostname)) return null;
+    if (parsed.username || parsed.password) return null;
+    if (parsed.port && parsed.port !== "443") return null;
+    if (!parsed.pathname.startsWith("/")) return null;
+    if (parsed.pathname.includes("..")) return null;
+
+    return parsed.toString();
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -35,11 +43,12 @@ export async function POST(req: NextRequest) {
 
   // Prediction successful --> upload output to supabase storage --> update db output url --> user receives output via supabase realtime
   if (status === "succeeded") {
-    if (!isAllowedOutputUrl(output)) {
+    const safeOutputUrl = getValidatedOutputUrl(output);
+    if (!safeOutputUrl) {
       return new Response("Invalid output URL", { status: 400 });
     }
 
-    const blob = await fetch(output).then((res) => res.blob());
+    const blob = await fetch(safeOutputUrl).then((res) => res.blob());
     const { data: storageData, error: storageError } = await supabase.storage
       .from("output")
       .upload(`/${data?.user_id}/${id}`, blob, {


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/extrapolate/security/code-scanning/1](https://github.com/lisagorewitdecker/extrapolate/security/code-scanning/1)

General fix: never pass raw user input to outbound requests. Parse and validate the URL against a strict policy (scheme, hostname allowlist, default port only, no credentials, expected path format), then use the normalized parsed URL for `fetch`.

Best fix here (same functionality preserved):  
In `app/api/webhooks/replicate/[id]/route.ts`, replace the boolean validator with a parser/validator that returns a canonical URL string (or `null`). Enforce:
- `https:` only
- hostname in `ALLOWED_OUTPUT_HOSTS`
- no username/password
- no explicit non-default port
- path starts with `/` and does not contain traversal patterns (`..`)
Then, in the success branch, validate `output` into `safeOutputUrl` and call `fetch(safeOutputUrl)` instead of `fetch(output)`.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
